### PR TITLE
Code clean-up

### DIFF
--- a/code/0-activityinfo.R
+++ b/code/0-activityinfo.R
@@ -2,11 +2,15 @@
 # Uncomment if needed or to update the package
 
 ## Activity Info R package
-install.packages("devtools")
-library(devtools)
- install_github( "bedatadriven/activityinfo-R", ref = "release")
-
-install_github( "bedatadriven/activityinfo-R", ref = "development")
+# Install packages if not present
+if(!("devtools" %in% installed.packages())) {
+  install.packages("devtools")
+}
+# Ensure that a recent version of the 'activityinfo' package is installed:
+if(!"activityinfo" %in% installed.packages() || packageVersion("activityinfo") < "0.4.17") {
+  library(devtools)
+  install_github( "bedatadriven/activityinfo-R", ref = "release")
+}
 
 library(activityinfo)
 
@@ -14,7 +18,6 @@ library(activityinfo)
 ### ActivityInfo Login
 
 # required packages:
-require("activityinfo")
 require("reshape2")
 
 # authenticate

--- a/code/0-packages.R
+++ b/code/0-packages.R
@@ -5,7 +5,7 @@
 packages <- c("ggplot2",
               "httr",
              # "xlsx",  
-              "rjson", "RCurl", "reshape2","plyr", "data.table")
+              "rjson", "RCurl", "reshape2", "plyr", "data.table")
 if (length(setdiff(packages, rownames(installed.packages()))) > 0) {
   install.packages(setdiff(packages, rownames(installed.packages())))  
 }

--- a/code/extract/1-data-monitor2016_V2.R
+++ b/code/extract/1-data-monitor2016_V2.R
@@ -9,7 +9,7 @@
 # authenticate
 #activityInfoLogin()
 
-# Uncomment when you run for the first time during yout session
+# Uncomment when you run for the first time during your session
 source("code/0-activityinfo.R")
 #
 source("code/0-packages.R")
@@ -128,8 +128,8 @@ extractOldId <- function(s) {
 }
 
 determineMonth <- function(start, end) {
-  start <- as.POSIXlt(start)
-  end <- as.POSIXlt(end)
+  start <- as.POSIXlt(start, format = "%Y-%m-%d", tz = "GMT")
+  end <- as.POSIXlt(end, format = "%Y-%m-%d", tz = "GMT")
   if (start$year != end$year || start$mon != end$mon) {
     cat("Warning: found a start and end date in different months\n")
   }


### PR DESCRIPTION
R's `as.POSIXlt` seems to have a problem with some date strings even if they are in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. The changes herein may help, but I can't reproduce the issue on my own system.
